### PR TITLE
Fix setLocalPressure

### DIFF
--- a/ios/RNBarometer.m
+++ b/ios/RNBarometer.m
@@ -73,7 +73,7 @@ RCT_EXPORT_METHOD(startObserving) {
                // Calculate our vertical speed in metres per second
                float verticalSpeed = ((self->altitudeASL - lastAltitudeASL) / timeSinceLastUpdate) * 1000;
                // Calculate our altitude based on our local pressure
-               self->altitude = getAltitude(self->localPressurehPa, self->rawPressure);
+               self->altitude = getAltitude(STANDARD_ATMOSPHERE, self->localPressurehPa);
                // Get the relative altitude
                float relativeAltitude = altitudeData.relativeAltitude.longValue;
                // Send change events to the Javascript side via the React Native bridge 


### PR DESCRIPTION
When using setLocalPressure() I was getting weird new altitudes, going from 293m with ASL to -90m after setting local hPa. It looks to me like the getAltitude() function needs to use STANDARD_ATMOSPHERE as the first argument, and not use the rawPressure at all.

Caveats: I know virtually nothing about Obj-C or barometric data, so if this isn't right, hopefully it at least helps with a fix.