### PR TITLE
Equal smoothing treatment

### DIFF
--- a/android/src/main/java/com/sensorworks/RNBarometer/RNBarometerModule.java
+++ b/android/src/main/java/com/sensorworks/RNBarometer/RNBarometerModule.java
@@ -61,7 +61,7 @@ public class RNBarometerModule extends ReactContextBaseJavaModule implements Lif
     mRelativeAltitude = 0;
     mInitialAltitude = -1;
     mIntervalMillis = DEFAULT_INTERVAL_MS;
-    mFilterFactor = DEFAULT_FILTER_FACTOR;
+    mSmoothingFactor = DEFAULT_SMOOTHING_FACTOR;
     isRunning = false;
   }
 
@@ -178,7 +178,7 @@ public class RNBarometerModule extends ReactContextBaseJavaModule implements Lif
     long timeSinceLastUpdate = tempMs - mLastSampleTime;
     if (timeSinceLastUpdate >= mIntervalMillis) {
       double lastAltitudeASL = mAltitudeASL;
-      // Get the filtered raw pressure in millibar/hPa
+      // Get the smoothed raw pressure in millibar/hPa
       mRawPressure = (sensorEvent.values[0] * (((double)1.0) - mSmoothingFactor) + mRawPressure * mSmoothingFactor);
       // Calculate standard atmosphere altitude in metres
       mAltitudeASL = getAltitude(SensorManager.PRESSURE_STANDARD_ATMOSPHERE, mRawPressure);

--- a/android/src/main/java/com/sensorworks/RNBarometer/RNBarometerModule.java
+++ b/android/src/main/java/com/sensorworks/RNBarometer/RNBarometerModule.java
@@ -29,7 +29,7 @@ public class RNBarometerModule extends ReactContextBaseJavaModule implements Lif
   
   public static final String NAME = "RNBarometer";
 
-  public static final double DEFAULT_INTERVAL_MS = 200;  //  5 Hz
+  public static final int DEFAULT_INTERVAL_MS = 200;  //  5 Hz
   public static final double DEFAULT_SMOOTHING_FACTOR = 0.7;
 
   private static final int ignoreSamples = 10;

--- a/android/src/main/java/com/sensorworks/RNBarometer/RNBarometerModule.java
+++ b/android/src/main/java/com/sensorworks/RNBarometer/RNBarometerModule.java
@@ -139,8 +139,8 @@ public class RNBarometerModule extends ReactContextBaseJavaModule implements Lif
 
   @ReactMethod
   // Gets smoothing factor
-  public double getSmoothingFactor() {
-    return mSmoothingFactor;
+  public double getSmoothingFactor(Promise promise) {
+    return promise.resolve(mSmoothingFactor);
   }
 
   @ReactMethod

--- a/android/src/main/java/com/sensorworks/RNBarometer/RNBarometerModule.java
+++ b/android/src/main/java/com/sensorworks/RNBarometer/RNBarometerModule.java
@@ -140,7 +140,7 @@ public class RNBarometerModule extends ReactContextBaseJavaModule implements Lif
   @ReactMethod
   // Gets smoothing factor
   public void getSmoothingFactor(Promise promise) {
-    return promise.resolve(mSmoothingFactor);
+    promise.resolve(mSmoothingFactor);
   }
 
   @ReactMethod

--- a/android/src/main/java/com/sensorworks/RNBarometer/RNBarometerModule.java
+++ b/android/src/main/java/com/sensorworks/RNBarometer/RNBarometerModule.java
@@ -139,7 +139,7 @@ public class RNBarometerModule extends ReactContextBaseJavaModule implements Lif
 
   @ReactMethod
   // Gets smoothing factor
-  public double getSmoothingFactor(Promise promise) {
+  public void getSmoothingFactor(Promise promise) {
     return promise.resolve(mSmoothingFactor);
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,11 +5,43 @@
 // https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html
 // https://stackoverflow.com/a/51355583
 
+// declare module "react-native-barometer";
+
+// import Barometer from ".";
+
+// interface BarometerPayload {  // See README for field descriptions
+//   timestamp:number,
+//   pressure:number,
+//   altitudeASL:number,
+//   altitude:number,
+//   relativeAltitude:number,
+//   verticalSpeed:number,
+// };
+
+// type WatchCallbackFn = (payload:BarometerPayload) => void;
+
+// interface IBarometer {
+//   watch: (watchCallbackFn:WatchCallbackFn) => number,
+//   clearWatch: (watchID:number) => void,
+//   stopObserving: () => void,
+//   isSupported: () => Promise<boolean>,
+//   setInterval: (interval:number) => void,
+//   setLocalPressure: (pressure:number) => void,
+// };
+
+// declare const Barometer:IBarometer;
+
+// export {
+//   Barometer,
+//   BarometerPayload,
+//   WatchCallbackFn
+// };
+
+// export default Barometer;
+
 declare module "react-native-barometer";
 
-import Barometer from ".";
-
-interface BarometerPayload {  // See README for descriptions
+interface BarometerPayload {  // See README for field descriptions
   timestamp:number,
   pressure:number,
   altitudeASL:number,
@@ -18,23 +50,14 @@ interface BarometerPayload {  // See README for descriptions
   verticalSpeed:number,
 };
 
-type WatchCallbackFn = (payload:BarometerPayload) => void;
-
-interface IBarometer {
-  watch: (watchCallbackFn:WatchCallbackFn) => number,
-  clearWatch: (watchID:number) => void,
-  stopObserving: () => void,
-  isSupported: () => Promise<boolean>,
-  setInterval: (interval:number) => void,
-  setLocalPressure: (pressure:number) => void,
-};
-
-declare const Barometer:IBarometer;
-
-export {
-  Barometer,
-  BarometerPayload,
-  WatchCallbackFn
-};
+type BarometerWatchCallbackFn = (payload:BarometerPayload) => void;
 
 export default Barometer;
+declare namespace Barometer {
+    function watch(success: BarometerWatchCallbackFn): number;
+    function clearWatch(watchID: any): void;
+    function stopObserving(): void;
+    function isSupported(): Promise<any>;
+    function setInterval(interval: any): void;
+    function setLocalPressure(pressure: any): void;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,8 @@ declare const Barometer:IBarometer;
 
 export {
   Barometer,
-  BarometerPayload
+  BarometerPayload,
+  WatchCallbackFn
 };
 
 export default Barometer;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@
 
 declare module "react-native-barometer";
 
-interface Payload {  // See README for descriptions
+interface BarometerPayload {  // See README for descriptions
   timestamp:number,
   pressure:number,
   altitudeASL:number,
@@ -16,7 +16,7 @@ interface Payload {  // See README for descriptions
   verticalSpeed:number,
 };
 
-type WatchCallbackFn = (payload:Payload) => number;
+type WatchCallbackFn = (payload:BarometerPayload) => number;
 
 interface IBarometer {
   watch: WatchCallbackFn,
@@ -30,7 +30,8 @@ interface IBarometer {
 declare const Barometer:IBarometer;
 
 export {
-  Barometer
+  Barometer,
+  BarometerPayload
 };
 
 export default Barometer;

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ interface BarometerPayload {  // See README for descriptions
 type WatchCallbackFn = (payload:BarometerPayload) => number;
 
 interface IBarometer {
-  watch: WatchCallbackFn,
+  watch: (watchCallbackFn:WatchCallbackFn) => number,
   clearWatch: (watchID:number) => void,
   stopObserving: () => void,
   isSupported: () => Promise<boolean>,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,50 @@
-//import Barometer from "."
+// Module d.ts file; enables this module to be used
+// in typescript react-native projects
+
+// If keeping the interface below up-to-date proves
+// to be a nuissance, options are:
+//
+// * Comment out everything below except the "declare module..." line
+//   (which enables this module to be used in typescript
+//   react-native projects). Cons: You lose auto-complete and 
+//   type-checking in VS Code, but, if the types defined by 
+//   the interface below aren't there - they can't be *wrong*.
+// 
+// * Re-create this module using create-react-native-library,
+//   choosing typescript, and java/obj-c. See:
+//   https://reactnative.dev/docs/native-modules-setup,
+//  
+
+// See:
+// https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html
+// https://stackoverflow.com/a/51355583
 
 declare module "react-native-barometer";
 
+interface Payload {  // See README for descriptions
+  timestamp:number,
+  pressure:number,
+  altitudeASL:number,
+  altitude:number,
+  relativeAltitude:number,
+  verticalSpeed:number,
+};
+
+type WatchCallbackFn = (payload:Payload) => number;
+
 interface IBarometer {
-  watch: (watchCallbackFn:Function) => number,
+  watch: WatchCallbackFn,
   clearWatch: (watchID:number) => void,
   stopObserving: () => void,
   isSupported: () => Promise<boolean>,
   setInterval: (interval:number) => void,
   setLocalPressure: (pressure:number) => void,
-}
+};
 
 declare const Barometer:IBarometer;
+
+export {
+  Barometer
+};
+
 export default Barometer;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+declare module "react-native-barometer";

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,19 +1,5 @@
-// Module d.ts file; enables this module to be used
+// Module d.ts file; enables using this module
 // in typescript react-native projects
-
-// If keeping the interface below up-to-date proves
-// to be a nuissance, options are:
-//
-// * Comment out everything below except the "declare module..." line
-//   (which enables this module to be used in typescript
-//   react-native projects). Cons: You lose auto-complete and 
-//   type-checking in VS Code, but, if the types defined by 
-//   the interface below aren't there - they can't be *wrong*.
-// 
-// * Re-create this module using create-react-native-library,
-//   choosing typescript, and java/obj-c. See:
-//   https://reactnative.dev/docs/native-modules-setup,
-//  
 
 // See:
 // https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ interface BarometerPayload {  // See README for descriptions
   verticalSpeed:number,
 };
 
-type WatchCallbackFn = (payload:BarometerPayload) => number;
+type WatchCallbackFn = (payload:BarometerPayload) => void;
 
 interface IBarometer {
   watch: (watchCallbackFn:WatchCallbackFn) => number,

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,8 @@ declare namespace Barometer {  // See module README for function descriptions
   function watch(success: BarometerWatchCallbackFn): number;
   function clearWatch(watchID: any): void;
   function stopObserving(): void;
+  function setSmoothingFactor(smoothingFactor:double): void;
+  function getSmoothingFactor(): Promise<double>;
 }
 
 export {

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,8 @@
 
 declare module "react-native-barometer";
 
+import Barometer from ".";
+
 interface BarometerPayload {  // See README for descriptions
   timestamp:number,
   pressure:number,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,47 +1,19 @@
-// Module d.ts file; enables using this module
-// in typescript react-native projects
+// Module d.ts file
+
+// Enables using module in typescript react-native projects,
+// with editor auto-complete and type-validation (in VS Code)
 
 // See:
-// https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html
+// Typescript docs:
+//   https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html
+// Typescript Playground, for automatic generation of .d.ts file from .js:
+//   https://www.typescriptlang.org/play?filetype=js&useJavaScript=true#code/Q
+// Simplest approach:
 // https://stackoverflow.com/a/51355583
-
-// declare module "react-native-barometer";
-
-// import Barometer from ".";
-
-// interface BarometerPayload {  // See README for field descriptions
-//   timestamp:number,
-//   pressure:number,
-//   altitudeASL:number,
-//   altitude:number,
-//   relativeAltitude:number,
-//   verticalSpeed:number,
-// };
-
-// type WatchCallbackFn = (payload:BarometerPayload) => void;
-
-// interface IBarometer {
-//   watch: (watchCallbackFn:WatchCallbackFn) => number,
-//   clearWatch: (watchID:number) => void,
-//   stopObserving: () => void,
-//   isSupported: () => Promise<boolean>,
-//   setInterval: (interval:number) => void,
-//   setLocalPressure: (pressure:number) => void,
-// };
-
-// declare const Barometer:IBarometer;
-
-// export {
-//   Barometer,
-//   BarometerPayload,
-//   WatchCallbackFn
-// };
-
-// export default Barometer;
 
 declare module "react-native-barometer";
 
-interface BarometerPayload {  // See README for field descriptions
+interface BarometerPayload {  // See module README for field descriptions
   timestamp:number,
   pressure:number,
   altitudeASL:number,
@@ -52,12 +24,18 @@ interface BarometerPayload {  // See README for field descriptions
 
 type BarometerWatchCallbackFn = (payload:BarometerPayload) => void;
 
-export default Barometer;
-declare namespace Barometer {
-    function watch(success: BarometerWatchCallbackFn): number;
-    function clearWatch(watchID: any): void;
-    function stopObserving(): void;
-    function isSupported(): Promise<any>;
-    function setInterval(interval: any): void;
-    function setLocalPressure(pressure: any): void;
+declare namespace Barometer {  // See module README for function descriptions
+  function isSupported(): Promise<boolean>;
+  function setInterval(interval: number): void;
+  function setLocalPressure(pressure: number): void;
+  function watch(success: BarometerWatchCallbackFn): number;
+  function clearWatch(watchID: any): void;
+  function stopObserving(): void;
 }
+
+export {
+  BarometerPayload,
+  BarometerWatchCallbackFn
+};
+
+export default Barometer;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,15 @@
+//import Barometer from "."
+
 declare module "react-native-barometer";
+
+interface IBarometer {
+  watch: (watchCallbackFn:Function) => number,
+  clearWatch: (watchID:number) => void,
+  stopObserving: () => void,
+  isSupported: () => Promise<boolean>,
+  setInterval: (interval:number) => void,
+  setLocalPressure: (pressure:number) => void,
+}
+
+declare const Barometer:IBarometer;
+export default Barometer;

--- a/index.js
+++ b/index.js
@@ -84,8 +84,8 @@ const Barometer = {
     RNBarometer.setSmoothingFactor(smoothingFactor);
   },
 
-  getSmoothingFactor: function() {
-    return RNBarometer.getSmoothingFactor();
+  getSmoothingFactor: async function() {
+    return await RNBarometer.getSmoothingFactor();
   }
 
 };

--- a/index.js
+++ b/index.js
@@ -73,6 +73,19 @@ const Barometer = {
   // Sets the local air pressure in hPA/Millibars
   setLocalPressure: function(pressure) {
     RNBarometer.setLocalPressure(pressure);
+  },
+
+  // Sets smoothingFactor, a value [0 - 1] that determines
+  // how much smoothing is applied to the raw value.
+  // Note: More smoothing means more latency before
+  // the smoothed value has "caught up with" current
+  // conditions.
+  setSmoothingFactor: function(smoothingFactor) {
+    RNBarometer.setSmoothingFactor(smoothingFactor);
+  },
+
+  getSmoothingFactor: function() {
+    return RNBarometer.getSmoothingFactor();
   }
 
 };

--- a/ios/RNBarometer.h
+++ b/ios/RNBarometer.h
@@ -13,6 +13,7 @@
     double rawPressure;
     double altitudeASL;
     double altitude;
+    double smoothingFactor;
 }
 
 @end

--- a/ios/RNBarometer.m
+++ b/ios/RNBarometer.m
@@ -8,6 +8,8 @@
 #import <React/RCTLog.h>
 
 const double STANDARD_ATMOSPHERE = 1013.25;
+const double DEFAULT_INTERVAL_MS = 0.7;  //  5 Hz
+const double DEFAULT_SMOOTHING_FACTOR = 0.7;
 
 @implementation RNBarometer
 
@@ -24,8 +26,9 @@ RCT_EXPORT_MODULE()
     rawPressure = 0;
     altitudeASL = 0;
     lastSampleTime = 0;
-    intervalMillis = 200; // 5Hz
+    intervalMillis = DEFAULT_INTERVAL_MS;
     isRunning = false;
+    smoothingFactor = DEFAULT_SMOOTHING_FACTOR;
   }
   return self;
 }
@@ -62,6 +65,24 @@ RCT_EXPORT_METHOD(setLocalPressure:(NSInteger) pressurehPa) {
   localPressurehPa = pressurehPa;
 }
 
+// Sets smoothing factor [0 -1].
+// Note: More smoothing means more latency before
+// the smoothed value has "caught up with" current
+// conditions.
+RCT_EXPORT_METHOD(setSmoothingFactor:(double) smoothingFactor) {
+  if (smoothingFactor >= 0 && smoothingFactor <= 1.0) {
+    self->smoothingFactor = smoothingFactor;
+  }
+}
+
+// Get the smoothing factor
+RCT_EXPORT_METHOD(getSmoothingFactor,
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+  return resolve(self->smoothingFactor);
+}
+
+
 // Starts observing pressure
 RCT_EXPORT_METHOD(startObserving) {
   if(!isRunning) {
@@ -71,7 +92,9 @@ RCT_EXPORT_METHOD(startObserving) {
       if(timeSinceLastUpdate >= self->intervalMillis && altitudeData){
         double lastAltitudeASL = self->altitudeASL;
         // Get the raw pressure in millibar/hPa
-        self->rawPressure = altitudeData.pressure.doubleValue * 10.0; // the x10 converts to millibar
+        double newRawPressure = altitudeData.pressure.doubleValue * 10.0; // the x10 converts to millibar
+        // Apply any smoothing
+        self->rawPressure = (newRawPressure * (((double)1.0) - mSmoothingFactor) + self->rawPressure * mSmoothingFactor);
         // Calculate standard atmpsphere altitude in metres
         self->altitudeASL = getAltitude(STANDARD_ATMOSPHERE, self->rawPressure);
         // Calculate our vertical speed in metres per second
@@ -114,6 +137,7 @@ double getAltitude(double p0, double p)
   const double coef = 1.0 / 5.255;
   return 44330.0 * (1.0 - pow(p/p0, coef));
 }
+
 
 @end
 

--- a/ios/RNBarometer.m
+++ b/ios/RNBarometer.m
@@ -8,7 +8,7 @@
 #import <React/RCTLog.h>
 
 const double STANDARD_ATMOSPHERE = 1013.25;
-const double DEFAULT_INTERVAL_MS = 0.7;  //  5 Hz
+const long DEFAULT_INTERVAL_MS = 0.7;  //  5 Hz
 const double DEFAULT_SMOOTHING_FACTOR = 0.7;
 
 @implementation RNBarometer


### PR DESCRIPTION
Currently, this library applies filtering/smoothing for values on Android devices, but does _not_ (yet) apply filtering/smoothing for iOS devices. As a result, behavior seems inconsistent across platforms.

This PR normalizes smoothing/filtering, so that it is handled the same way across both platforms.

It provides two related methods: 
```js
setSmoothingFactor(smoothingFactor)  // where smoothingFactor is a number [0.0-1.0]
getSmoothingFactor()  // async
```
... and employs the pre-existing default filtering value/equation for Android, i.e: smoothed = 0.3*new + (1.0 - 0.3)*old

This PR includes the changes of PR #4, enabling this library to be used in typescript react-native projects.